### PR TITLE
Add encoding comments for Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 
-* Python (tested with 3.6)
+* Python (tested with 2.7, 3.6)
 * Django
 * Django Rest Framework
 

--- a/drf_firebase_auth/apps.py
+++ b/drf_firebase_auth/apps.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.apps import AppConfig
 
 

--- a/drf_firebase_auth/authentication.py
+++ b/drf_firebase_auth/authentication.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Authentication backend for handling firebase user.idToken from incoming
 Authorization header, verifying, and locally authenticating

--- a/drf_firebase_auth/models.py
+++ b/drf_firebase_auth/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Models for storing the uid of authenticating firebase users and relating them
 to the local AUTH_USER_MODEL model.

--- a/drf_firebase_auth/settings.py
+++ b/drf_firebase_auth/settings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Settings config for the drf_firebase_auth application
 Author: Gary Burgmann


### PR DESCRIPTION
Needed this to fix an error on startup with Python 2.7 / Django 1.11 due to a fancy ’ in `authentication.py`

Should be harmless otherwise.