### PR TITLE
Commit initial database migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,9 @@ DRF_FIREBASE_AUTH = {
 }
 ```
 
-Now that you have configured the application, make and run the migrations so that the Firebase data can be stored.
+Now that you have configured the application, run the migrations so that the Firebase data can be stored.
 
 ```
-$ ./manage.py makemigrations drf_firebase_auth
 $ ./manage.py migrate drf_firebase_auth
 ```
 

--- a/drf_firebase_auth/migrations/0001_initial.py
+++ b/drf_firebase_auth/migrations/0001_initial.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='FirebaseUser',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('uid', models.CharField(max_length=191)),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='firebase_user', related_query_name='firebase_user', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='FirebaseUserProvider',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('uid', models.CharField(max_length=191)),
+                ('provider_id', models.CharField(max_length=50)),
+                ('firebase_user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='provider', related_query_name='provider', to='drf_firebase_auth.FirebaseUser')),
+            ],
+        ),
+    ]
+


### PR DESCRIPTION
Not sure if it was an intentional decision for trade-offs I'm not aware of, if it is I'm happy to run with a fork.

Most apps seem to come with data migrations committed to package though, and it makes most deployment workflows I'm aware of much cleaner. (Automatically rebuilding is tricky if it needs specific commands at a certain point when a package is added)

Django also seem to assume committing them as default, eg: https://docs.djangoproject.com/en/2.1/topics/migrations/#workflow

