### PR TITLE
Add option for anonymous requests

### DIFF
--- a/drf_firebase_auth/authentication.py
+++ b/drf_firebase_auth/authentication.py
@@ -14,6 +14,7 @@ from firebase_admin import auth as firebase_auth
 from django.utils.encoding import smart_text
 from django.utils import timezone
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 from rest_framework import (
     authentication,
     exceptions
@@ -38,6 +39,14 @@ class BaseFirebaseAuthentication(authentication.BaseAuthentication):
     Token based authentication using firebase.
     """
     def authenticate(self, request):
+        """
+        With ALLOW_ANONYMOUS_REQUESTS, set request.user to an AnonymousUser, 
+        allowing us to configure access at the permissions level.
+        """
+        authorization_header = authentication.get_authorization_header(request)
+        if api_settings.ALLOW_ANONYMOUS_REQUESTS and not authorization_header:
+            return (AnonymousUser(), None)
+
         """
         Returns a tuple of len(2) of `User` and the decoded firebase token if
         a valid signature has been supplied using Firebase authentication.

--- a/drf_firebase_auth/settings.py
+++ b/drf_firebase_auth/settings.py
@@ -13,6 +13,8 @@ from rest_framework.settings import APISettings
 USER_SETTINGS = getattr(settings, 'DRF_FIREBASE_AUTH', None)
 
 DEFAULTS = {
+    # allow anonymous requests without Authorization header set
+    'ALLOW_ANONYMOUS_REQUESTS': False,
     # path to JSON file with firebase secrets
     'FIREBASE_SERVICE_ACCOUNT_KEY': '',
     # allow creation of new local user in db


### PR DESCRIPTION
Adds the option for a request without any `Authorization: JWT ...` header to be passed through as an `AnonymousUser` (per main Django auth) rather than raise an exception.

This allows views to use `FirebaseAuthentication` for authentication, but still have public / generally available views, via custom permissions.

A great example is a content API for a public-facing website, allowing public, unauthenticated access to the API on a read-only basis, but requiring an admin login to `POST` / `PUT` / `DELETE`, etc.

The option is an opt-in, configurable via `settings. DRF_FIREBASE_AUTH.ALLOW_ANONYMOUS_REQUESTS` so that default behaviour is unchanged.