### PR TITLE
fix 'firebase_admin.auth' has no attribute 'AuthError'

### DIFF
--- a/drf_firebase_auth/authentication.py
+++ b/drf_firebase_auth/authentication.py
@@ -124,7 +124,10 @@ class FirebaseAuthentication(BaseFirebaseAuthentication):
                 'JWT was found to be invalid, or the App’s project ID cannot '
                 'be determined.'
             )
-        except firebase_auth.AuthError as exc:
+        except (firebase_auth.InvalidIdTokenError, 
+                firebase_auth.ExpiredIdTokenError, 
+                firebase_auth.RevokedIdTokenError, 
+                firebase_auth.CertificateFetchError) as exc:
             if exc.code == 'ID_TOKEN_REVOKED':
                 raise exceptions.AuthenticationFailed(
                     'Token revoked, inform the user to reauthenticate or '


### PR DESCRIPTION
When the user use wrong JWT token the server raise the error rest_framework.request.WrappedAttributeError: module 'firebase_admin.auth' has no attribute 'AuthError'.
requirements:
Django==2.2.5
djangorestframework==3.10.3
drf-firebase-auth==0.0.6
firebase-admin==3.2.0
...
