### PR TITLE
authenticate_token() method called nonexistent firebase_admin.auth.AuthError

### DIFF
--- a/drf_firebase_auth/authentication.py
+++ b/drf_firebase_auth/authentication.py
@@ -155,7 +155,7 @@ class FirebaseAuthentication(BaseFirebaseAuthentication):
             raise exceptions.AuthenticationFailed(
                 'User ID is None, empty or malformed'
             )
-        except firebase_auth.AuthError:
+        except firebase_auth.UserNotFoundError:
             raise exceptions.AuthenticationFailed(
                 'Error retrieving the user, or the specified user ID does not '
                 'exist'


### PR DESCRIPTION
The authenticate_token() method on the FirebaseAuthentication class was calling firebase_admin.auth.AuthError. This error does not exist, causing the authenticate method to fail.

The most appropriate existing error I could find was firebase_admin.auth.UserNotFoundError, so I updated it with that. A list of all errors available on firebase_admin.auth (if you don't like UserNotFoundError) can be found here: https://firebase.google.com/docs/reference/admin/python/firebase_admin.auth.