### PR TITLE
feat: added firebase_user.phone_number for mapping email field

### DIFF
--- a/drf_firebase_auth/authentication.py
+++ b/drf_firebase_auth/authentication.py
@@ -22,7 +22,7 @@ from .models import (
     FirebaseUser,
     FirebaseUserProvider
 )
-from .utils import get_firebase_user_email
+from .utils import get_firebase_user_identifier
 from . import __title__
 
 log = logging.getLogger(__title__)
@@ -98,7 +98,7 @@ class FirebaseAuthentication(authentication.TokenAuthentication):
         """
         Attempts to return or create a local User from Firebase user data
         """
-        email = get_firebase_user_email(firebase_user)
+        email = get_firebase_user_identifier(firebase_user)
         log.info(f'_get_or_create_local_user - email: {email}')
         user = None
         try:

--- a/drf_firebase_auth/utils.py
+++ b/drf_firebase_auth/utils.py
@@ -7,11 +7,12 @@ from firebase_admin import auth
 
 def get_firebase_user_email(firebase_user: auth.UserRecord) -> str:
     try:
-        return (
-            firebase_user.email
-            if firebase_user.email
-            else firebase_user.provider_data[0].email
-        )
+        if firebase_user.email:
+            return firebase_user.email
+        elif firebase_user.phone_number:
+            return firebase_user.phone_number
+        else:
+            firebase_user.provider_data[0].email
     except Exception as e:
         raise Exception(e)
 

--- a/drf_firebase_auth/utils.py
+++ b/drf_firebase_auth/utils.py
@@ -5,14 +5,18 @@ import uuid
 from firebase_admin import auth
 
 
-def get_firebase_user_email(firebase_user: auth.UserRecord) -> str:
+def get_firebase_user_identifier(firebase_user: auth.UserRecord) -> str:
     try:
         if firebase_user.email:
             return firebase_user.email
+        elif firebase_user.provider_data[0].email:
+            firebase_user.provider_data[0].email
         elif firebase_user.phone_number:
             return firebase_user.phone_number
+        elif firebase_user.provider_data[0].phone_number:
+            return firebase_user.provider_data[0].phone_number
         else:
-            firebase_user.provider_data[0].email
+            raise Exception("Identifier not found, this would fail authentication process")
     except Exception as e:
         raise Exception(e)
 
@@ -51,7 +55,7 @@ def map_firebase_email_to_username(
     firebase_user: auth.UserRecord
 ) -> str:
     try:
-        return get_firebase_user_email(firebase_user)
+        return get_firebase_user_identifier(firebase_user)
     except Exception as e:
         raise Exception(e)
 

--- a/drf_firebase_auth/utils.py
+++ b/drf_firebase_auth/utils.py
@@ -10,7 +10,7 @@ def get_firebase_user_identifier(firebase_user: auth.UserRecord) -> str:
         if firebase_user.email:
             return firebase_user.email
         elif firebase_user.provider_data[0].email:
-            firebase_user.provider_data[0].email
+            return firebase_user.provider_data[0].email
         elif firebase_user.phone_number:
             return firebase_user.phone_number
         elif firebase_user.provider_data[0].phone_number:

--- a/testapp/api/tests.py
+++ b/testapp/api/tests.py
@@ -10,7 +10,7 @@ import firebase_admin
 from firebase_admin import auth as firebase_auth
 from drf_firebase_auth.settings import api_settings
 from drf_firebase_auth.utils import (
-    get_firebase_user_email,
+    get_firebase_user_identifier,
     map_firebase_uid_to_username,
     map_firebase_email_to_username
 )
@@ -25,7 +25,7 @@ firebase = firebase_admin.initialize_app(
 )
 
 class WhoAmITests(APITestCase):
-    
+
     def setUp(self):
         self._url = reverse('whoami')
         self._test_user_email = 'user@example.com'
@@ -103,7 +103,7 @@ class WhoAmITests(APITestCase):
                 status.HTTP_403_FORBIDDEN,
                 f'{api_settings.FIREBASE_CREATE_LOCAL_USER}'
             )
-        
+
         with self._MOCK_FIREBASE_CREATE_LOCAL_USER_TRUE:
             response = self.client.get(self._url)
             self.assertEqual(
@@ -143,11 +143,11 @@ class WhoAmITests(APITestCase):
             )
         )
         firebase_user = self._get_test_user()
-        firebase_user_email = get_firebase_user_email(firebase_user)
+        firebase_user_email = get_firebase_user_identifier(firebase_user)
 
         with self._MOCK_FIREBASE_CREATE_LOCAL_USER_FALSE:
             before_count = User.objects.count()
-            
+
             response = self.client.get(self._url)
             self.assertEqual(
                 response.status_code,
@@ -161,11 +161,11 @@ class WhoAmITests(APITestCase):
 
             with self.assertRaises(Exception):
                 _ = User.objects.get(email=firebase_user_email)
-        
+
         with self._MOCK_FIREBASE_CREATE_LOCAL_USER_TRUE:
             with self._MOCK_FIREBASE_USERNAME_MAPPING_FUNC_UID:
                 before_count = User.objects.count()
-                
+
                 response = self.client.get(self._url)
                 self.assertEqual(
                     response.status_code,
@@ -193,11 +193,11 @@ class WhoAmITests(APITestCase):
             )
         )
         firebase_user = self._get_test_user()
-        firebase_user_email = get_firebase_user_email(firebase_user)
+        firebase_user_email = get_firebase_user_identifier(firebase_user)
 
         with self._MOCK_FIREBASE_CREATE_LOCAL_USER_FALSE:
             before_count = User.objects.count()
-            
+
             response = self.client.get(self._url)
             self.assertEqual(
                 response.status_code,
@@ -211,11 +211,11 @@ class WhoAmITests(APITestCase):
 
             with self.assertRaises(Exception):
                 _ = User.objects.get(email=firebase_user_email)
-        
+
         with self._MOCK_FIREBASE_CREATE_LOCAL_USER_TRUE:
             with self._MOCK_FIREBASE_USERNAME_MAPPING_FUNC_EMAIL:
                 before_count = User.objects.count()
-                
+
                 response = self.client.get(self._url)
                 self.assertEqual(
                     response.status_code,


### PR DESCRIPTION
I did make a minor change, whereas, the phone number, if the user is registered with it in firebase, would be mapped to the email field in `auth_user`. I did run unit tests within my app with the phone number and it is expected to work absolutely fine in production mode (I did not run it in my CI/CD pipeline). My app's settings were by default:

```python
# drf_firebase_auth settings

DRF_FIREBASE_AUTH = {
    # allow anonymous requests without Authorization header set
    "ALLOW_ANONYMOUS_REQUESTS": os.getenv("ALLOW_ANONYMOUS_REQUESTS", False),
    # path to JSON file with firebase secrets
    "FIREBASE_SERVICE_ACCOUNT_KEY": json.loads(
        env(
            "FIREBASE_SERVICE_ACCOUNT_KEY",
        )
    ),
    # allow creation of new local user in db
    "FIREBASE_CREATE_LOCAL_USER": os.getenv("FIREBASE_CREATE_LOCAL_USER", True),
    # attempt to split firebase user.display_name and set local user
    # first_name and last_name
    "FIREBASE_ATTEMPT_CREATE_WITH_DISPLAY_NAME": os.getenv(
        "FIREBASE_ATTEMPT_CREATE_WITH_DISPLAY_NAME", True
    ),
    # commonly JWT or Bearer (e.g. JWT <token>)
    "FIREBASE_AUTH_HEADER_PREFIX": os.getenv("FIREBASE_AUTH_HEADER_PREFIX", "Bearer"),
    # verify that JWT has not been revoked
    "FIREBASE_CHECK_JWT_REVOKED": os.getenv("FIREBASE_CHECK_JWT_REVOKED", True),
    # require that firebase user.email_verified is True
    "FIREBASE_AUTH_EMAIL_VERIFICATION": os.getenv(
        "FIREBASE_AUTH_EMAIL_VERIFICATION", False
    ),
    # function should accept firebase_admin.auth.UserRecord as argument
    # and return str
    "FIREBASE_USERNAME_MAPPING_FUNC": map_firebase_uid_to_username,
}
```

The only thing is that the current email field should be identifier instead of email in `auth_user`