### PR TITLE
ImportError fix

### DIFF
--- a/drf_firebase_auth/authentication.py
+++ b/drf_firebase_auth/authentication.py
@@ -8,7 +8,6 @@ import logging
 
 import firebase_admin
 from firebase_admin import auth as firebase_auth
-from django.utils.encoding import smart_text
 from django.utils import timezone
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser


### PR DESCRIPTION
Removed unused `smart_text` import from the authentication.py. This line causes ImportError on Django 4.0